### PR TITLE
73 add workflow to create branch from issue

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,2 +1,38 @@
-# Configuration file for ./workflows/create-branch-issue.yml
-
+### Configuration file for ./workflows/create-branch-issue.yml
+# Have branches be created when issue is assniged
+mode: auto
+# Use naming scheme of "issue-[id]"
+branchName: short
+# Auto-close an issue after the corresponding PR has been merged into `develop`
+autoCloseIssue: true
+branches:
+  # Prefix based on issue
+  - label: model
+    prefix: model/
+  - label: bug
+    prefix: bugfix/
+  # Skip based on label
+  - label: duplicate
+    skip: true
+  - label: help wanted
+    skip: true
+  - label: question
+    skip: true
+  # Open PR to merge `develop` into `release` when issue has label "release"
+  - label: release
+    name: develop
+    prTarget: release
+    skipBranch: true
+# Open a Draft PR on issue creation
+openDraftPR: true
+# Skip CI workflows on empty commits on  PR creation (This "Feature" is a GH requirement)
+# Copy attributes from issue into PR
+copyIssueDescriptionToPR: true
+copyIssueLabelsToPR: true
+copyIssueAssigneeToPR: true
+copyIssueProjectsToPR: true
+copyIssueMilestoneToPR: true
+# Create "[Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)" message (See [here](https://github.com/marketplace/actions/create-issue-branch#conventional-pull-request-titles))
+conventionalPrTitles: true
+# Use semantic versioning with gitmoji
+conventionalStyle: semver

--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,2 @@
+# Configuration file for ./workflows/create-branch-issue.yml
+

--- a/.github/workflows/create-branch-issue.yml
+++ b/.github/workflows/create-branch-issue.yml
@@ -1,0 +1,20 @@
+on:
+  # The issues event below is only needed for the default (auto) mode,
+  # you can remove it otherwise
+  issues:
+    types: [ assigned ]
+  # The issue_comment event below is only needed for the ChatOps mode,
+  # you can remove it otherwise
+  issue_comment:
+    types: [ created ]
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  create_issue_branch_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Issue Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-branch-issue.yml
+++ b/.github/workflows/create-branch-issue.yml
@@ -18,3 +18,16 @@ jobs:
         uses: robvanderleek/create-issue-branch@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: add pr link in comment
+        uses: mshick/add-pr-comment@master
+        if: steps.create-issue-branch.outputs.branchName != ''
+        env:
+          PULL_REQUEST_URL: ${{ format('https://github.com/{0}/compare/{1}...{2}?quick_pull=1&template={3}', github.repository, github.event.repository.default_branch, steps.create-issue-branch.outputs.branchName, steps.template.outputs.template-name) }}
+          TEMPLATE: ${{ steps.template.outputs.template-name }}
+        with:
+          message: |
+            ## Pull Request ![](https://raw.githubusercontent.com/primer/octicons/master/icons/git-pull-request-16.svg)
+
+            [Create a pull request](${{ env.PULL_REQUEST_URL }}) for the issue branch using the `${{ env.TEMPLATE }}` template.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: "github-actions[bot]"


### PR DESCRIPTION
## Pull Request

### Description
(From Issue #73 )
The current "Add Branch from Issue" workflow GitHub provides doesn't seem to meet my workflow in the way I had hoped it would.

This PR enhances the "Issue -> Branch -> Development -> PR -> Merge" workflow by adding additional QoL features, such as named auto-branch creation ("An issue labelled with "model" would create a branch prefixed with "model/issue-78", and the PR would get auto-created as well, and copy all relevant information from the issue it's referencing.

### Related Issues
Closes #73 

### Checklist
<!-- Ensure all the following items are completed before submitting the pull request. -->
- [X] Code follows the project's coding standards.
- [X] Documentation is updated (if applicable).
- [X] All checks and tests pass locally.
- [X] The commit messages follow the project's [commit message conventions](../CONTRIBUTING.md))

---

By submitting this pull request, I confirm that my contributions are made under the terms of the project's license.
