### PR TITLE
Remove part from hand after installing it

### DIFF
--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
@@ -44,6 +44,7 @@ local removePartFromPart = function(player, item, partName)
 end
 
 local installFirearmPart = function(player, item, part)
+	ISInventoryPaneContextMenu.equipWeapon(item, true, false, player:getPlayerNum());
 	ISInventoryPaneContextMenu.equipWeapon(part, false, false, player:getPlayerNum());
 	ISTimedActionQueue.add(ISInstallFirearmPart:new(player, item, part, 60*2))
 end

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/ISInstallFirearmPart.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/ISInstallFirearmPart.lua
@@ -58,7 +58,7 @@ function ISInstallFirearmPart:perform()
 		self.character:getInventory():Remove(tItem)
 		-- remove installed part from hand
 		-- we had to put it in our hand in order to install it (see FirearmContextMenu.lua)
-		self.character:setPrimaryHandItem(nil)
+		self.character:setSecondaryHandItem(nil)
 
 		-- initialize data
 		heldParts[tType] = FIREARMS.initializeDataForPart(tType)

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/ISInstallFirearmPart.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/ISInstallFirearmPart.lua
@@ -56,6 +56,9 @@ function ISInstallFirearmPart:perform()
 	if not heldParts[tType] then
 		-- remove installed part from inventory
 		self.character:getInventory():Remove(tItem)
+		-- remove installed part from hand
+		-- we had to put it in our hand in order to install it (see FirearmContextMenu.lua)
+		self.character:setPrimaryHandItem(nil)
 
 		-- initialize data
 		heldParts[tType] = FIREARMS.initializeDataForPart(tType)


### PR DESCRIPTION
## Pull Request

### Description

Call `self.character:setPrimaryHandItem(nil)` after removing the item from the inventory. This seems to be what TIS is doing elsewhere.

### Related Issues
Resolves #95 

### Checklist
<!-- Ensure all the following items are completed before submitting the pull request. -->
- [x] Code follows the project's coding standards.
- [x] Documentation is updated (if applicable).
- [x] All checks and tests pass locally.
- [x] The commit messages follow the project's [commit message conventions](../CONTRIBUTING.md))

### Additional Notes

## How to create a good Pull Request

For guidelines on how to best create a Pull Request for this project, please refer to "[How to create a Pull Request](../CONTRIBUTING.md#creating-a-pull-request)"

---

By submitting this pull request, I confirm that my contributions are made under the terms of the project's license.
