### PR TITLE
Fix condition of parts not being handled consistently

### DIFF
--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
@@ -95,8 +95,9 @@ local checkInventoryItem = function(player, context, item)
 			return
 		end
 
+		-- initialize this part
+		FIREARMS.initializePartItem(item)
 		local data = FIREARMS.getModData(item)
-		FIREARMS.initializeComponentModData(item)
 
 		-- add info
 		local infoOption = context:addOption(getText("ContextMenu_Firearm_AssemblyInfo"), item, nil)
@@ -137,8 +138,11 @@ local checkInventoryItem = function(player, context, item)
 			-- for each item of this type
 			for k=0, parts:size() - 1 do
 				local part = parts:get(k)
-				FIREARMS.initializeComponentModData(part)
+				
+				-- initialize other part
+				FIREARMS.initializePartItem(part)
 				local partData = FIREARMS.getModData(part)
+
 				-- if a part of this type is not already installed
 				if not partData.parts[type] then
 					local option = subMenuInstall:addOption(part:getName(), player, installFirearmPart, part, item)

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmContextMenu.lua
@@ -138,7 +138,7 @@ local checkInventoryItem = function(player, context, item)
 			-- for each item of this type
 			for k=0, parts:size() - 1 do
 				local part = parts:get(k)
-				
+
 				-- initialize other part
 				FIREARMS.initializePartItem(part)
 				local partData = FIREARMS.getModData(part)

--- a/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmsHelper.lua
+++ b/src/Contents/mods/coavinsfirearms/media/lua/client/coavinsfirearms/FirearmsHelper.lua
@@ -367,6 +367,7 @@ end
 
 this.getModData = function(item)
 	if not item:getModData().coavinsfirearms then
+		print("Creating mod data for item: " .. item:getFullType())
 		item:getModData().coavinsfirearms = {}
 	end
 	return item:getModData().coavinsfirearms
@@ -410,7 +411,7 @@ this.initializeFirearmModData = function(firearm)
 end
 
 this.initializeDataForPart = function(type, data, guaranteedParts, overrideConditionPct)
-	print("Initializing part: " .. type)
+	print("Initializing mod data for part: " .. type)
 	local model = this.getPartModel(type)
 
 	-- this function either creates a new table (and returns it)
@@ -447,7 +448,7 @@ this.initializeDataForPart = function(type, data, guaranteedParts, overrideCondi
 			print(string.format('rolled condition %.2f between %.2f and %.2f', initialConditionPct, initialMin, initialMax))
 		end
 
-		data.condition = data.conditionMax * initialConditionPct
+		data.condition = math.floor(data.conditionMax * initialConditionPct)
 		print(string.format('set new condition: %.2f', data.condition))
 	else
 		-- we already determined a condition for this part
@@ -474,11 +475,14 @@ this.initializeDataForPart = function(type, data, guaranteedParts, overrideCondi
 	return data
 end
 
-this.initializeComponentModData = function(item)
+this.initializePartItem = function(item)
+	print("Initializing part: " .. item:getFullType())
 	local type = item:getType()
 	local data = this.getModData(item)
 
 	this.initializeDataForPart(type, data)
+
+	item:setCondition(data.condition)
 end
 
 this.checkConditionForAllParts = function(model, installedParts, damage)
@@ -652,13 +656,17 @@ this.copyDataFromParent = function(parentItem, childItem)
 
 	local newData
 	if data then
-		-- copy data to child
+		-- copy data from parent
 		newData = this.tableDeepCopy(data)
 	else
 		-- no data, this item hasn't been disassembled before
 		newData = this.initializeDataForPart(childType)
 	end
 
+	-- copy data to child
+	childData.condition = newData.condition
+	childData.conditionLowerChance = newData.conditionLowerChance
+	childData.conditionMax = newData.conditionMax
 	childData.parts = newData.parts
 
 	-- apply condition


### PR DESCRIPTION
## Pull Request

### Description
These changes resolve some issues that cause the condition of a part to change unintentionally when it is involved in assembly and disassembly.

* Update item condition when condition is rolled for mod data
* Copy part condition from firearm mod data when disassembling
* Use only integral numbers when storing condition in mod data

### Related Issues
Resolves #97 

### Checklist
<!-- Ensure all the following items are completed before submitting the pull request. -->
- [ ] Code follows the project's coding standards.
- [ ] Documentation is updated (if applicable).
- [ ] All checks and tests pass locally.
- [ ] The commit messages follow the project's [commit message conventions](../CONTRIBUTING.md))

### Additional Notes

## How to create a good Pull Request

For guidelines on how to best create a Pull Request for this project, please refer to "[How to create a Pull Request](../CONTRIBUTING.md#creating-a-pull-request)"

---

By submitting this pull request, I confirm that my contributions are made under the terms of the project's license.
